### PR TITLE
Fix undefined values in getAbsence

### DIFF
--- a/lib/resources/absence.js
+++ b/lib/resources/absence.js
@@ -11,14 +11,23 @@ module.exports = class Absence extends tools.Resource {
    * @returns {Promise}
    */
   getAbsence(id) {
-    return this.api
+    const checkForUndefined = (data) => {
+      for (const el in data) {
+        if (data[el] === undefined) return true;
+        else continue;
+      }
+
+      return false;
+    }
+
+    const absenceData = this.api
       ._tableMapper(
           `przegladaj_nb/szczegoly/${id}`
         , "table.decorated tbody"
         , [ "type"
+          , "category"
           , "date"
           , "subject"
-          , "topic"
           , "lessonHour"
           , "teacher"
           , "trip"
@@ -26,10 +35,35 @@ module.exports = class Absence extends tools.Resource {
         ]
       )
       .then(data => {
-        return _.assign(data, {
-          trip: tools.makeBoolean(data.trip)
-        });
+        if (checkForUndefined(data)) {
+          // Dual check, because some absences can have 8 values and another 7.
+          return this.api
+          ._tableMapper(
+              `przegladaj_nb/szczegoly/${id}`
+            , "table.decorated tbody"
+            , [ "type"
+              , "date"
+              , "subject"
+              , "lessonHour"
+              , "teacher"
+              , "trip"
+              , "addedBy"
+            ]
+          )
+          .then(secData => {
+            return _.assign(secData, {
+              trip: tools.makeBoolean(data.trip)
+            });
+          })
+        }
+        else {
+          return _.assign(data, {
+            trip: tools.makeBoolean(data.trip)
+          });
+        }
       });
+
+    return absenceData;
   }
 
   /**


### PR DESCRIPTION
Added dual check for get absence data, because some absences can have 8 values and another 7 (For example 'Nk' has 8 fields and 'Nb' has 7).